### PR TITLE
makes conference names link to google search

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,7 +28,22 @@
               <h1>{{ page.title }}</h1>
             </header>
             <section>
+
               {{ content }}
+
+              <!-- finding-speaking-opportunities -->
+              {% if page.conferences %}
+                <ul>
+                  {% for conf_name in page.conferences %}
+                    <li>
+                      <a href = "https://www.google.com/search?q={{ conf_name }}">
+                        {{ conf_name }}
+                      </a>
+                    </li>
+                  {% endfor %}
+                </ul>
+              {% endif %}
+
             </section>
           </article>
 

--- a/finding-speaking-opportunities.md
+++ b/finding-speaking-opportunities.md
@@ -1,86 +1,92 @@
 ---
 title:  "Finding you hundreds of conference speaking opportunities"
 layout: default
+
+conferences:
+
+  - ACE! Conference
+  - Agile Alliance / Agile2014
+  - Agile on the Beach
+  - Ancient City Ruby
+  - AnDevCon
+  - APIstrategyConf
+  - Berlin Buzzwords
+  - Blogging While Brown
+  - bmoreresponsive
+  - BoosterConf
+  - BSDCan
+  - CasITConf
+  - Clojure/West
+  - Converge Conf
+  - Devoxx France
+  - Devs Love Bacon
+  - DjangoWeekend
+  - DroidCon
+  - EmberConf
+  - ErlangFactory
+  - Euroia
+  - EuroPython
+  - Eurostar Software Testing Conference
+  - FOSS4G
+  - GigaOM
+  - GLSEC
+  - GrrCon
+  - HTML5DevConf
+  - IBM Impact
+  - iOSonRails
+  - JSConf
+  - JSConf Brazil
+  - JSconf Uruguay
+  - JSFest
+  - Kansas City Developer Conference
+  - Kod.io
+  - Lone Star PHP
+  - MagmaConf
+  - MDevCon
+  - MetaRefresh
+  - Mobdevcon
+  - Monitorama
+  - Mountain West JS
+  - Mountain West RubyConf
+  - MtnWest DevOps
+  - MtnWest HackWeek
+  - NDC
+  - NoSQL Matters
+  - Notacon
+  - O'Reilly Velocity
+  - OpsCode ChefConf
+  - OSCON
+  - PASS SQLSaturday
+  - PGCon
+  - PHP[tek]
+  - Puppet Conf
+  - PuppetCamp Silicon Valley
+  - PuppetCamp Sydney
+  - PyData Conf
+  - RailsConf
+  - Ruby on Ales
+  - RubyConf India
+  - RubyConf Phillipines
+  - RubyConf Taiwan
+  - ScotlandJS
+  - Southern California Linux Expo
+  - SPA (Software Practice Advancement)
+  - StirTrek
+  - Titanium Conference
+  - UIKonf
+  - UX Madison
+  - UXPA
+  - Windy City Rails
+  - Women In Technology
+  - Write The Docs Europe
+  - Write The Docs North America
+  - Wroc_Love
+
 ---
 
 It's hard to find opportunities to speak at programming conferences. For people who are underrepresented in the programming field, or new, it's especially daunting. [@CallbackWomen](http://twitter.com/callbackwomen) digs up hundreds of those opportunities. We also try to get other crucial information for you, such as travel funding and code of conduct policy.
 
 Here's a sampling of the eighty open CFPs we found among programming conferences in just _one_ recent month.  Follow [@CallbackWomen](http://twitter.com/callbackwomen) to discover future opportunities like these.
 
-  * ACE! Conference
-  * Agile Alliance / Agile2014
-  * Agile on the Beach
-  * Ancient City Ruby
-  * AnDevCon
-  * APIstrategyConf
-  * Berlin Buzzwords
-  * Blogging While Brown
-  * bmoreresponsive
-  * BoosterConf
-  * BSDCan
-  * CasITConf
-  * Clojure/West
-  * Converge Conf
-  * Devoxx France
-  * Devs Love Bacon
-  * DjangoWeekend
-  * DroidCon
-  * EmberConf
-  * ErlangFactory
-  * Euroia
-  * EuroPython
-  * Eurostar Software Testing Conference
-  * FOSS4G
-  * GigaOM
-  * GLSEC
-  * GrrCon
-  * HTML5DevConf
-  * IBM Impact
-  * iOSonRails
-  * JSConf
-  * JSConf Brazil
-  * JSconf Uruguay
-  * JSFest
-  * Kansas City Developer Conference
-  * Kod.io
-  * Lone Star PHP
-  * MagmaConf
-  * MDevCon
-  * MetaRefresh
-  * Mobdevcon
-  * Monitorama
-  * Mountain West JS
-  * Mountain West RubyConf
-  * MtnWest DevOps
-  * MtnWest HackWeek
-  * NDC
-  * NoSQL Matters
-  * Notacon
-  * O'Reilly Velocity
-  * OpsCode ChefConf
-  * OSCON
-  * PASS SQLSaturday
-  * PGCon
-  * PHP\[tek\]
-  * Puppet Conf
-  * PuppetCamp Silicon Valley
-  * PuppetCamp Sydney
-  * PyData Conf
-  * RailsConf
-  * Ruby on Ales
-  * RubyConf India
-  * RubyConf Phillipines
-  * RubyConf Taiwan 
-  * ScotlandJS
-  * Southern California Linux Expo
-  * SPA (Software Practice Advancement)
-  * StirTrek
-  * Titanium Conference
-  * UIKonf
-  * UX Madison
-  * UXPA
-  * Windy City Rails
-  * Women In Technology
-  * Write The Docs Europe
-  * Write The Docs North America
-  * Wroc_Love
+
+


### PR DESCRIPTION
makes conference names in list on finding-speaking-opportunities page link to a google search for each name